### PR TITLE
integration test with data_type passing; reuse NewDataRequestArgs in …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,6 +2426,7 @@ name = "request-interface"
 version = "0.1.0"
 dependencies = [
  "near-sdk",
+ "oracle",
  "serde",
 ]
 

--- a/oracle/tests/it/utils/account_utils.rs
+++ b/oracle/tests/it/utils/account_utils.rs
@@ -87,7 +87,7 @@ impl TestAccount {
                     challenge_period: U64(1000),
                     settlement_time: U64(10000),
                     target_contract: TARGET_CONTRACT_ID.to_string(),
-                    data_type: data_request::DataRequestDataType::String,
+                    data_type: DataRequestDataType::String
                 }
             }).to_string().as_bytes(),
             DEFAULT_GAS,
@@ -126,7 +126,7 @@ impl TestAccount {
                 "request_id": U64(dr_id)
             }).to_string().as_bytes(),
             DEFAULT_GAS,
-            900000000000000000000
+            1000000000000000000000
         );
 
         res.assert_success();
@@ -145,7 +145,7 @@ impl TestAccount {
                 "request_id": U64(dr_id)
             }).to_string().as_bytes(),
             DEFAULT_GAS,
-            900000000000000000000
+            1000000000000000000000
         );
 
         res.assert_success();

--- a/request-interface/Cargo.toml
+++ b/request-interface/Cargo.toml
@@ -4,9 +4,7 @@ version = "0.1.0"
 authors = ["Jameson Hodge <contact@jamesonhodge.com>"]
 edition = "2018"
 
-[lib]
-crate-type = ["cdylib", "rlib"]
-
 [dependencies]
 near-sdk = { git = "https://github.com/near/near-sdk-rs.git", rev="249dacdcd3fd34bc00f0895a275f33f05cd910c1" }
+oracle = { path = "./../oracle" }
 serde = "1.0.118"

--- a/request-interface/src/lib.rs
+++ b/request-interface/src/lib.rs
@@ -1,33 +1,18 @@
+extern crate oracle;
+
 use near_sdk::{env, near_bindgen, AccountId, Balance, Promise};
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::serde::{ Deserialize, Serialize };
 use near_sdk::serde_json::json;
 use near_sdk::json_types::{U64, U128};
 use fungible_token_handler::fungible_token_transfer_call;
-
-near_sdk::setup_alloc!();
+use oracle::callback_args::NewDataRequestArgs;
 
 mod fungible_token_handler;
 
+near_sdk::setup_alloc!();
+
 pub type WrappedTimestamp = U64;
 pub type WrappedBalance = U128;
-
-#[derive(BorshSerialize, BorshDeserialize, Deserialize, Serialize)]
-pub struct Source {
-    pub end_point: String,
-    pub source_path: String
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct NewDataRequestArgs {
-    pub sources: Vec<Source>,
-    pub tags: Option<Vec<String>>,
-    pub description: Option<String>,
-    pub outcomes: Option<Vec<String>>,
-    pub challenge_period: WrappedTimestamp,
-    pub settlement_time: WrappedTimestamp,
-    pub target_contract: AccountId,
-}
 
 #[near_bindgen]
 #[derive(BorshDeserialize, BorshSerialize)]
@@ -86,6 +71,7 @@ mod tests {
     use super::*;
     use near_sdk::MockedBlockchain;
     use near_sdk::{testing_env, VMContext};
+    use oracle::data_request::DataRequestDataType;
 
     fn alice() -> AccountId {
         "alice.near".to_string()
@@ -157,6 +143,7 @@ mod tests {
             target_contract: target(),
             description: Some("a".to_string()),
             tags: None,
+            data_type: DataRequestDataType::String
         });
     }
 }


### PR DESCRIPTION
- For request interface contract, imported DataRequestDataType from oracle::data_request to match the shape to make integration test pass