### PR TITLE
Feat/fee config inside oracle config

### DIFF
--- a/oracle/src/data_request.rs
+++ b/oracle/src/data_request.rs
@@ -246,8 +246,7 @@ impl DataRequestChange for DataRequest {
         let fee: Balance = match custom_fee {
             CustomFeeStake::Fixed(f) => f.into(),
             CustomFeeStake::Multiplier(_) | CustomFeeStake::None =>
-                // config.resolution_fee_percentage as Balance * 
-                100 * 
+                config.fee.resolution_fee_percentage as Balance * 
                 tvl_of_requestor / 
                 PERCENTAGE_DIVISOR as Balance
         };
@@ -749,8 +748,8 @@ mod mock_token_basic_tests {
     use near_sdk::{ MockedBlockchain };
     use near_sdk::{ testing_env, VMContext };
     use crate::whitelist::{CustomFeeStakeArgs, RegistryEntry};
-    use fee_config::FeeConfig;
     use super::*;
+    use fee_config::FeeConfig;
 
     fn alice() -> AccountId {
         "alice.near".to_string()
@@ -804,14 +803,11 @@ mod mock_token_basic_tests {
             default_challenge_window_duration: U64(1000),
             min_initial_challenge_window_duration: U64(1000),
             final_arbitrator_invoke_amount: U128(250),
-        }
-    }
-
-    fn fee_config() -> FeeConfig {
-        FeeConfig {
-            flux_market_cap: U128(50000),
-            total_value_staked: U128(10000),
-            resolution_fee_percentage: 5000, // 5%
+            fee: FeeConfig {
+                flux_market_cap: U128(50000),
+                total_value_staked: U128(10000),
+                resolution_fee_percentage: 10_000,
+            }
         }
     }
 
@@ -841,7 +837,7 @@ mod mock_token_basic_tests {
     fn dr_new_single_outcome() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
 
         contract.dr_new(bob(), 100, 5, NewDataRequestArgs{
             sources: Vec::new(),
@@ -862,7 +858,7 @@ mod mock_token_basic_tests {
     fn dr_new_non_whitelisted() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         contract.dr_new(alice(), 100, 5, NewDataRequestArgs{
             sources: Vec::new(),
             outcomes: None,
@@ -881,7 +877,7 @@ mod mock_token_basic_tests {
     fn dr_new_non_bond_token() {
         testing_env!(get_context(alice()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         contract.dr_new(bob(), 100, 5, NewDataRequestArgs{
             sources: Vec::new(),
             outcomes: None,
@@ -900,7 +896,7 @@ mod mock_token_basic_tests {
     fn dr_new_arg_source_exceed() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         let x1 = data_request::Source {end_point: "1".to_string(), source_path: "1".to_string()};
         let x2 = data_request::Source {end_point: "2".to_string(), source_path: "2".to_string()};
         let x3 = data_request::Source {end_point: "3".to_string(), source_path: "3".to_string()};
@@ -928,7 +924,7 @@ mod mock_token_basic_tests {
     fn dr_new_arg_outcome_exceed() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
 
         contract.dr_new(bob(), 100, 5, NewDataRequestArgs{
             sources: Vec::new(),
@@ -958,7 +954,7 @@ mod mock_token_basic_tests {
     fn dr_description_required_no_sources() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         contract.dr_new(bob(), 100, 5, NewDataRequestArgs{
             sources: vec![],
             outcomes: None,
@@ -977,7 +973,7 @@ mod mock_token_basic_tests {
     fn dr_new_arg_challenge_period_below_min() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
 
         contract.dr_new(bob(), 100, 5, NewDataRequestArgs{
             sources: Vec::new(),
@@ -997,7 +993,7 @@ mod mock_token_basic_tests {
     fn dr_new_arg_challenge_period_exceed() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
 
         contract.dr_new(bob(), 100, 5, NewDataRequestArgs{
             sources: Vec::new(),
@@ -1017,7 +1013,7 @@ mod mock_token_basic_tests {
     fn dr_new_not_enough_amount() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
 
         contract.dr_new(bob(), 90, 5, NewDataRequestArgs{
             sources: Vec::new(),
@@ -1036,7 +1032,7 @@ mod mock_token_basic_tests {
     fn dr_new_success_exceed_amount() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
 
         let amount : Balance = contract.dr_new(bob(), 200, 5, NewDataRequestArgs{
             sources: Vec::new(),
@@ -1056,7 +1052,7 @@ mod mock_token_basic_tests {
     fn dr_new_success() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
 
         let amount : Balance = contract.dr_new(bob(), 100, 5, NewDataRequestArgs{
             sources: Vec::new(),
@@ -1091,7 +1087,7 @@ mod mock_token_basic_tests {
     fn dr_stake_non_stake_token() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
 
         testing_env!(get_context(alice()));
@@ -1106,7 +1102,7 @@ mod mock_token_basic_tests {
     fn dr_stake_not_existing() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         contract.dr_stake(alice(),100,  StakeDataRequestArgs{
             id: U64(0),
             outcome: data_request::Outcome::Answer(AnswerType::String("42".to_string()))
@@ -1118,7 +1114,7 @@ mod mock_token_basic_tests {
     fn dr_stake_incompatible_answer() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
 
         contract.dr_stake(alice(),100,  StakeDataRequestArgs{
@@ -1132,7 +1128,7 @@ mod mock_token_basic_tests {
     fn dr_stake_finalized_market() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
 
         contract.dr_stake(alice(), 200, StakeDataRequestArgs{
@@ -1158,7 +1154,7 @@ mod mock_token_basic_tests {
     fn dr_stake_finalized_settlement_time() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
 
         contract.dr_new(bob(), 100, 5, NewDataRequestArgs{
             sources: Vec::new(),
@@ -1182,7 +1178,7 @@ mod mock_token_basic_tests {
     fn dr_stake_success_partial() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
 
         let _b = contract.dr_stake(alice(), 5, StakeDataRequestArgs{
@@ -1205,7 +1201,7 @@ mod mock_token_basic_tests {
     fn dr_stake_success_full_at_t0() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
 
         let _b = contract.dr_stake(alice(), 200, StakeDataRequestArgs{
@@ -1232,7 +1228,7 @@ mod mock_token_basic_tests {
     fn dr_stake_success_overstake_at_t600() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
 
         let mut ct : VMContext = get_context(token());
@@ -1266,7 +1262,7 @@ mod mock_token_basic_tests {
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
         let mut c: oracle_config::OracleConfig = config();
         c.final_arbitrator_invoke_amount = U128(150);
-        let mut contract = Contract::new(whitelist, c, fee_config());
+        let mut contract = Contract::new(whitelist, c);
         dr_new(&mut contract);
 
         contract.dr_stake(alice(), 200, StakeDataRequestArgs{
@@ -1282,7 +1278,7 @@ mod mock_token_basic_tests {
     fn dr_finalize_no_resolutions() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
 
         contract.dr_finalize(U64(0));
@@ -1293,7 +1289,7 @@ mod mock_token_basic_tests {
     fn dr_finalize_active_challenge() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
 
         contract.dr_stake(alice(), 200, StakeDataRequestArgs{
@@ -1308,7 +1304,7 @@ mod mock_token_basic_tests {
     fn dr_finalize_success() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
 
         contract.dr_stake(alice(), 200, StakeDataRequestArgs{
@@ -1332,7 +1328,7 @@ mod mock_token_basic_tests {
     fn dr_stake_same_outcome() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
 
         contract.dr_stake(alice(), 300, StakeDataRequestArgs{
@@ -1365,7 +1361,7 @@ mod mock_token_basic_tests {
     fn dr_unstake_invalid_id() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
 
         contract.dr_unstake(U64(0), 0, data_request::Outcome::Answer(AnswerType::String("a".to_string())), U128(0));
     }
@@ -1375,7 +1371,7 @@ mod mock_token_basic_tests {
     fn dr_unstake_bonded_outcome() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
         dr_finalize(&mut contract, data_request::Outcome::Answer(AnswerType::String("a".to_string())));
 
@@ -1387,7 +1383,7 @@ mod mock_token_basic_tests {
     fn dr_unstake_bonded_outcome_c() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
         dr_finalize(&mut contract, data_request::Outcome::Answer(AnswerType::String("a".to_string())));
 
@@ -1399,7 +1395,7 @@ mod mock_token_basic_tests {
     fn dr_unstake_too_much() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
 
         contract.dr_stake(alice(), 10, StakeDataRequestArgs{
@@ -1415,7 +1411,7 @@ mod mock_token_basic_tests {
     fn dr_unstake_success() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
 
         let outcome = data_request::Outcome::Answer(AnswerType::String("b".to_string()));
@@ -1454,7 +1450,7 @@ mod mock_token_basic_tests {
     fn dr_claim_invalid_id() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
 
         contract.dr_claim(alice(), U64(0));
     }
@@ -1463,7 +1459,7 @@ mod mock_token_basic_tests {
     fn dr_claim_success() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
         dr_finalize(&mut contract, data_request::Outcome::Answer(AnswerType::String("a".to_string())));
 
@@ -1474,7 +1470,7 @@ mod mock_token_basic_tests {
     fn d_claim_single() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
         dr_finalize(&mut contract, data_request::Outcome::Answer(AnswerType::String("a".to_string())));
 
@@ -1487,7 +1483,7 @@ mod mock_token_basic_tests {
     fn d_claim_same_twice() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
         dr_finalize(&mut contract, data_request::Outcome::Answer(AnswerType::String("a".to_string())));
 
@@ -1503,7 +1499,7 @@ mod mock_token_basic_tests {
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
         let mut config = config();
         config.validity_bond = U128(2);
-        let mut contract = Contract::new(whitelist, config, fee_config());
+        let mut contract = Contract::new(whitelist, config);
         dr_new(&mut contract);
         dr_finalize(&mut contract, data_request::Outcome::Answer(AnswerType::String("a".to_string())));
 
@@ -1516,7 +1512,7 @@ mod mock_token_basic_tests {
     fn d_claim_double() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
 
         contract.dr_stake(bob(), 100, StakeDataRequestArgs{
@@ -1537,7 +1533,7 @@ mod mock_token_basic_tests {
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
         let mut config = config();
         config.final_arbitrator_invoke_amount = U128(1000);
-        let mut contract = Contract::new(whitelist, config, fee_config());
+        let mut contract = Contract::new(whitelist, config);
         dr_new(&mut contract);
 
         contract.dr_stake(bob(), 200, StakeDataRequestArgs{
@@ -1558,7 +1554,7 @@ mod mock_token_basic_tests {
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
         let mut config = config();
         config.final_arbitrator_invoke_amount = U128(1000);
-        let mut contract = Contract::new(whitelist, config, fee_config());
+        let mut contract = Contract::new(whitelist, config);
         dr_new(&mut contract);
 
         contract.dr_stake(bob(), 200, StakeDataRequestArgs{
@@ -1584,7 +1580,7 @@ mod mock_token_basic_tests {
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
         let mut config = config();
         config.final_arbitrator_invoke_amount = U128(1000);
-        let mut contract = Contract::new(whitelist, config, fee_config());
+        let mut contract = Contract::new(whitelist, config);
         dr_new(&mut contract);
 
         contract.dr_stake(bob(), 200, StakeDataRequestArgs{
@@ -1611,7 +1607,7 @@ mod mock_token_basic_tests {
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
         let mut config = config();
         config.final_arbitrator_invoke_amount = U128(1000);
-        let mut contract = Contract::new(whitelist, config, fee_config());
+        let mut contract = Contract::new(whitelist, config);
         dr_new(&mut contract);
 
         contract.dr_stake(bob(), 100, StakeDataRequestArgs{
@@ -1644,7 +1640,7 @@ mod mock_token_basic_tests {
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
         let mut config = config();
         config.final_arbitrator_invoke_amount = U128(1000);
-        let mut contract = Contract::new(whitelist, config, fee_config());
+        let mut contract = Contract::new(whitelist, config);
         dr_new(&mut contract);
 
         contract.dr_stake(bob(), 200, StakeDataRequestArgs{
@@ -1675,7 +1671,7 @@ mod mock_token_basic_tests {
     fn d_claim_final_arb() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         // needed for final arb function
         dr_new(&mut contract);
 
@@ -1704,7 +1700,7 @@ mod mock_token_basic_tests {
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
         let mut config = config();
         config.final_arbitrator_invoke_amount = U128(600);
-        let mut contract = Contract::new(whitelist, config, fee_config());
+        let mut contract = Contract::new(whitelist, config);
         // needed for final arb function
         dr_new(&mut contract);
 
@@ -1739,7 +1735,7 @@ mod mock_token_basic_tests {
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
         let mut config = config();
         config.final_arbitrator_invoke_amount = U128(600);
-        let mut contract = Contract::new(whitelist, config, fee_config());
+        let mut contract = Contract::new(whitelist, config);
         // needed for final arb function
         dr_new(&mut contract);
 
@@ -1773,7 +1769,7 @@ mod mock_token_basic_tests {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
         let config = config();
-        let mut contract = Contract::new(whitelist, config, fee_config());
+        let mut contract = Contract::new(whitelist, config);
         dr_new(&mut contract);
 
         contract.dr_stake(alice(), 200, StakeDataRequestArgs{
@@ -1796,7 +1792,7 @@ mod mock_token_basic_tests {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
         let config = config();
-        let mut contract = Contract::new(whitelist, config, fee_config());
+        let mut contract = Contract::new(whitelist, config);
         // needed for final arb function
         dr_new(&mut contract);
 
@@ -1816,7 +1812,7 @@ mod mock_token_basic_tests {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
         let config = config();
-        let mut contract = Contract::new(whitelist, config, fee_config());
+        let mut contract = Contract::new(whitelist, config);
         // needed for final arb function
         dr_new(&mut contract);
 
@@ -1836,7 +1832,7 @@ mod mock_token_basic_tests {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
         let config = config();
-        let mut contract = Contract::new(whitelist, config, fee_config());
+        let mut contract = Contract::new(whitelist, config);
         // needed for final arb function
         dr_new(&mut contract);
 
@@ -1861,7 +1857,7 @@ mod mock_token_basic_tests {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
         let config = config();
-        let mut contract = Contract::new(whitelist, config, fee_config());
+        let mut contract = Contract::new(whitelist, config);
         // needed for final arb function
         dr_new(&mut contract);
 
@@ -1888,7 +1884,7 @@ mod mock_token_basic_tests {
     fn dr_stake_before_settlement_time() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         contract.dr_new(bob(), 100, 5, NewDataRequestArgs{
             sources: Vec::new(),
             outcomes: Some(vec!["a".to_string(), "b".to_string()].to_vec()),
@@ -1912,7 +1908,7 @@ mod mock_token_basic_tests {
     fn dr_tvl_increases() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         dr_new(&mut contract);
 
         let outcome = data_request::Outcome::Answer(AnswerType::String("b".to_string()));
@@ -1934,7 +1930,7 @@ mod mock_token_basic_tests {
         let whitelist = Some(vec![bob_requestor, registry_entry(carol())]);
         let mut config = config();
         config.validity_bond = U128(2);
-        let mut contract = Contract::new(whitelist, config, fee_config());
+        let mut contract = Contract::new(whitelist, config);
         contract.dr_new(bob(), 100, 5, NewDataRequestArgs{
             sources: Vec::new(),
             outcomes: Some(vec!["a".to_string(), "b".to_string()].to_vec()),
@@ -1966,7 +1962,7 @@ mod mock_token_basic_tests {
         let whitelist = Some(vec![bob_requestor, registry_entry(carol())]);
         let mut config = config();
         config.validity_bond = U128(2);
-        let mut contract = Contract::new(whitelist, config, fee_config());
+        let mut contract = Contract::new(whitelist, config);
         contract.dr_new(bob(), 100, 5, NewDataRequestArgs{
             sources: Vec::new(),
             outcomes: Some(vec!["a".to_string(), "b".to_string()].to_vec()),

--- a/oracle/src/fee_config.rs
+++ b/oracle/src/fee_config.rs
@@ -39,7 +39,7 @@ impl Contract {
         updated_config.fee = new_fee_config.clone();
         self.configs.replace(self.configs.len() - 1, &updated_config);
 
-        logger::log_fee_config(&new_fee_config);
+        logger::log_oracle_config(&updated_config, self.configs.len() - 1);
         helpers::refund_storage(initial_storage, env::predecessor_account_id());
     }
 }

--- a/oracle/src/fungible_token_receiver.rs
+++ b/oracle/src/fungible_token_receiver.rs
@@ -100,14 +100,11 @@ mod mock_token_basic_tests {
             default_challenge_window_duration: U64(1000),
             min_initial_challenge_window_duration: U64(1000),
             final_arbitrator_invoke_amount: U128(250),
-        }
-    }
-
-    fn fee_config() -> FeeConfig {
-        FeeConfig {
-            flux_market_cap: U128(50000),
-            total_value_staked: U128(10000),
-            resolution_fee_percentage: 5000, // 5%
+            fee: FeeConfig {
+                flux_market_cap: U128(50000),
+                total_value_staked: U128(10000),
+                resolution_fee_percentage: 5000, // 5%
+            }
         }
     }
 
@@ -137,7 +134,7 @@ mod mock_token_basic_tests {
     fn transfer_storage_no_funds() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
 
         contract.dr_new(bob(), 100, 5, NewDataRequestArgs{
             sources: Vec::new(),
@@ -164,7 +161,7 @@ mod mock_token_basic_tests {
     fn transfer_storage_funds() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
 
         contract.dr_new(bob(), 100, 5, NewDataRequestArgs{
             sources: Vec::new(),

--- a/oracle/src/fungible_token_receiver.rs
+++ b/oracle/src/fungible_token_receiver.rs
@@ -50,6 +50,7 @@ mod mock_token_basic_tests {
     use crate::storage_manager::StorageManager;
     use crate::whitelist::CustomFeeStakeArgs;
     use crate::data_request::AnswerType;
+    use fee_config::FeeConfig;
 
     fn alice() -> AccountId {
         "alice.near".to_string()
@@ -99,7 +100,14 @@ mod mock_token_basic_tests {
             default_challenge_window_duration: U64(1000),
             min_initial_challenge_window_duration: U64(1000),
             final_arbitrator_invoke_amount: U128(250),
-            resolution_fee_percentage: 0,
+        }
+    }
+
+    fn fee_config() -> FeeConfig {
+        FeeConfig {
+            flux_market_cap: U128(50000),
+            total_value_staked: U128(10000),
+            resolution_fee_percentage: 5000, // 5%
         }
     }
 
@@ -129,7 +137,7 @@ mod mock_token_basic_tests {
     fn transfer_storage_no_funds() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config());
+        let mut contract = Contract::new(whitelist, config(), fee_config());
 
         contract.dr_new(bob(), 100, 5, NewDataRequestArgs{
             sources: Vec::new(),
@@ -156,7 +164,7 @@ mod mock_token_basic_tests {
     fn transfer_storage_funds() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config());
+        let mut contract = Contract::new(whitelist, config(), fee_config());
 
         contract.dr_new(bob(), 100, 5, NewDataRequestArgs{
             sources: Vec::new(),

--- a/oracle/src/gov.rs
+++ b/oracle/src/gov.rs
@@ -1,0 +1,101 @@
+use crate::*;
+
+#[near_bindgen]
+impl Contract {
+    // @notice sets FLUX market cap (in terms of bond token) for fee calculation; callable only by council
+    pub fn set_market_cap(&mut self, market_cap: WrappedBalance) {
+        self.assert_gov();
+        // TODO: assert call from council
+        self.flux_market_cap = market_cap;
+        // TODO: log market cap change
+    }
+}
+
+impl Contract {
+    pub fn assert_gov(&self) {
+        let config = self.configs.iter().last().unwrap();
+        assert_eq!(
+            config.gov,
+            env::predecessor_account_id(),
+            "This method is only callable by the governance contract {}",
+            config.gov
+        );
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(test)]
+mod mock_token_basic_tests {
+    use near_sdk::{ MockedBlockchain };
+    use near_sdk::{ testing_env, VMContext };
+    use near_sdk::json_types::U128;
+    use super::*;
+
+    fn alice() -> AccountId {
+        "alice.near".to_string()
+    }
+    
+    fn bob() -> AccountId {
+        "bob.near".to_string()
+    }
+
+    fn token() -> AccountId {
+        "token.near".to_string()
+    }
+ 
+    fn gov() -> AccountId {
+        "gov.near".to_string()
+    }
+
+    fn config(gov: AccountId) -> oracle_config::OracleConfig {
+        oracle_config::OracleConfig {
+            gov,
+            final_arbitrator: alice(),
+            bond_token: token(),
+            stake_token: token(),
+            validity_bond: U128(0),
+            max_outcomes: 8,
+            default_challenge_window_duration: U64(1000),
+            min_initial_challenge_window_duration: U64(1000),
+            final_arbitrator_invoke_amount: U128(25_000_000_000_000_000_000_000_000_000_000),
+            resolution_fee_percentage: 0,
+        }
+    }
+
+    fn get_context(predecessor_account_id: AccountId) -> VMContext {
+        VMContext {
+            current_account_id: token(),
+            signer_account_id: bob(),
+            signer_account_pk: vec![0, 1, 2],
+            predecessor_account_id,
+            input: vec![],
+            block_index: 0,
+            block_timestamp: 0,
+            account_balance: 1000 * 10u128.pow(24),
+            account_locked_balance: 0,
+            storage_usage: 10u64.pow(6),
+            attached_deposit: 15600000000000000000000,
+            prepaid_gas: 10u64.pow(18),
+            random_seed: vec![0, 1, 2],
+            is_view: false,
+            output_data_receivers: vec![],
+            epoch_height: 0,
+        }
+    }
+
+    #[test]
+    fn g_set_market_cap() {
+        testing_env!(get_context(gov()));
+        let mut contract = Contract::new(None, config(gov()));
+        contract.set_market_cap(U128(500));
+    }
+    
+    #[test]
+    #[should_panic(expected = "This method is only callable by the governance contract gov.near")]
+    fn g_set_market_cap_invalid() {
+        testing_env!(get_context(gov()));
+        let mut contract = Contract::new(None, config(gov()));
+        testing_env!(get_context(bob()));
+        contract.set_market_cap(U128(500));
+    }
+}

--- a/oracle/src/gov.rs
+++ b/oracle/src/gov.rs
@@ -5,7 +5,6 @@ impl Contract {
     // @notice sets FLUX market cap (in terms of bond token) for fee calculation; callable only by council
     pub fn set_market_cap(&mut self, market_cap: WrappedBalance) {
         self.assert_gov();
-        // TODO: assert call from council
         self.flux_market_cap = market_cap;
         logger::log_update_market_cap(market_cap);
     }

--- a/oracle/src/gov.rs
+++ b/oracle/src/gov.rs
@@ -7,7 +7,7 @@ impl Contract {
         self.assert_gov();
         // TODO: assert call from council
         self.flux_market_cap = market_cap;
-        // TODO: log market cap change
+        logger::log_update_market_cap(market_cap);
     }
 }
 

--- a/oracle/src/lib.rs
+++ b/oracle/src/lib.rs
@@ -19,7 +19,7 @@ mod helpers;
 mod logger;
 mod upgrade;
 mod target_contract_handler;
-mod fee_config;
+pub mod fee_config;
 
 /// Mocks
 mod fungible_token;
@@ -59,8 +59,7 @@ impl Contract {
         let mut configs = Vector::new(b"c".to_vec());
         configs.push(&config);
         logger::log_oracle_config(&config, 0);
-
-        // TODO: log fee config
+        logger::log_fee_config(&fee_config);
 
         Self {
             whitelist: whitelist::Whitelist::new(initial_whitelist),

--- a/oracle/src/lib.rs
+++ b/oracle/src/lib.rs
@@ -65,7 +65,7 @@ impl Contract {
             data_requests: Vector::new(b"dr".to_vec()),
             validity_bond: 1.into(),
             accounts: LookupMap::new(b"a".to_vec()),
-            flux_market_cap: 0.into(),
+            flux_market_cap: u128::MAX.into(),
         }
     }
 }

--- a/oracle/src/lib.rs
+++ b/oracle/src/lib.rs
@@ -39,7 +39,6 @@ pub struct Contract {
     pub data_requests: Vector<DataRequest>,
     pub validity_bond: U128,
     pub accounts: LookupMap<AccountId, AccountStorageBalance>, // storage map
-    pub fee_config: fee_config::FeeConfig,
 }
 
 impl Default for Contract {
@@ -54,12 +53,10 @@ impl Contract {
     pub fn new(
         initial_whitelist: Option<Vec<RegistryEntry>>,
         config: oracle_config::OracleConfig,
-        fee_config: fee_config::FeeConfig,
     ) -> Self {
         let mut configs = Vector::new(b"c".to_vec());
         configs.push(&config);
         logger::log_oracle_config(&config, 0);
-        logger::log_fee_config(&fee_config);
 
         Self {
             whitelist: whitelist::Whitelist::new(initial_whitelist),
@@ -67,7 +64,6 @@ impl Contract {
             data_requests: Vector::new(b"dr".to_vec()),
             validity_bond: 1.into(),
             accounts: LookupMap::new(b"a".to_vec()),
-            fee_config,
         }
     }
 }

--- a/oracle/src/lib.rs
+++ b/oracle/src/lib.rs
@@ -19,6 +19,7 @@ mod helpers;
 mod logger;
 mod upgrade;
 mod target_contract_handler;
+mod gov;
 
 /// Mocks
 mod fungible_token;
@@ -37,8 +38,8 @@ pub struct Contract {
     pub configs: Vector<oracle_config::OracleConfig>,
     pub data_requests: Vector<DataRequest>,
     pub validity_bond: U128,
-    // Storage map
-    pub accounts: LookupMap<AccountId, AccountStorageBalance>
+    pub accounts: LookupMap<AccountId, AccountStorageBalance>, // storage map
+    pub flux_market_cap: WrappedBalance,
 }
 
 impl Default for Contract {
@@ -64,18 +65,7 @@ impl Contract {
             data_requests: Vector::new(b"dr".to_vec()),
             validity_bond: 1.into(),
             accounts: LookupMap::new(b"a".to_vec()),
+            flux_market_cap: 0.into(),
         }
-    }
-}
-
-impl Contract {
-    fn assert_gov(&self) {
-        let config = self.configs.iter().last().unwrap();
-        assert_eq!(
-            config.gov,
-            env::predecessor_account_id(),
-            "This method is only callable by the governance contract {}",
-            config.gov
-        );
     }
 }

--- a/oracle/src/logger.rs
+++ b/oracle/src/logger.rs
@@ -20,7 +20,6 @@ use crate::{
     oracle_config::{
         OracleConfig
     },
-    fee_config::FeeConfig,
     helpers::{
         ns_to_ms,
     }
@@ -97,6 +96,12 @@ pub fn log_oracle_config(config: &OracleConfig, id: u64) {
                 "default_challenge_window_duration": config.default_challenge_window_duration,
                 "min_initial_challenge_window_duration": config.min_initial_challenge_window_duration,
                 "final_arbitrator_invoke_amount": config.final_arbitrator_invoke_amount,
+                
+                "fee": {
+                    "flux_market_cap": config.fee.flux_market_cap,
+                    "total_value_staked": config.fee.total_value_staked,
+                    "resolution_fee_percentage": config.fee.resolution_fee_percentage,
+                },
 
                 "date": U64(ns_to_ms(env::block_timestamp())),
                 "block_height": U64(env::block_index()),
@@ -105,8 +110,6 @@ pub fn log_oracle_config(config: &OracleConfig, id: u64) {
         .to_string()
         .as_bytes()
     );
-    // also log fee config as it is contained in the oracle config
-    log_fee_config(&config.fee);
 }
 
 pub fn log_resolution_window(window: &ResolutionWindow) {
@@ -247,26 +250,6 @@ pub fn log_whitelist(requestor: &RegistryEntry, active: bool) {
                 "custom_fee": requestor.custom_fee,
                 "code_base_url": requestor.code_base_url,
                 "active": active,
-                "date": U64(ns_to_ms(env::block_timestamp())),
-                "block_height": U64(env::block_index()),
-            }
-        })
-        .to_string()
-        .as_bytes()
-    );
-}
-
-pub fn log_fee_config(fee_config: &FeeConfig) {
-    env::log(
-        json!({
-            "type": "fee_config",
-            "action": "update",
-            "cap_id": format!("fc_{}", env::block_index()),
-            "params": {
-                "id": format!("fc_{}", env::block_index()),
-                "flux_market_cap": fee_config.flux_market_cap,
-                "total_value_staked": fee_config.total_value_staked,
-                "resolution_fee_percentage": fee_config.resolution_fee_percentage,
                 "date": U64(ns_to_ms(env::block_timestamp())),
                 "block_height": U64(env::block_index()),
             }

--- a/oracle/src/logger.rs
+++ b/oracle/src/logger.rs
@@ -254,6 +254,24 @@ pub fn log_whitelist(requestor: &RegistryEntry, active: bool) {
     );
 }
 
+pub fn log_update_market_cap(market_cap: U128) {
+    env::log(
+        json!({
+            "type": "market_cap",
+            "action": "update",
+            "cap_id": format!("mc_{}", env::block_index()),
+            "params": {
+                "id": format!("mc_{}", env::block_index()),
+                "market_cap": market_cap,
+                "date": U64(ns_to_ms(env::block_timestamp())),
+                "block_height": U64(env::block_index()),
+            }
+        })
+        .to_string()
+        .as_bytes()
+    );
+}
+
 #[derive(serde::Serialize)]
 pub enum TransactionType {
     Stake,

--- a/oracle/src/logger.rs
+++ b/oracle/src/logger.rs
@@ -105,6 +105,8 @@ pub fn log_oracle_config(config: &OracleConfig, id: u64) {
         .to_string()
         .as_bytes()
     );
+    // also log fee config as it is contained in the oracle config
+    log_fee_config(&config.fee);
 }
 
 pub fn log_resolution_window(window: &ResolutionWindow) {

--- a/oracle/src/logger.rs
+++ b/oracle/src/logger.rs
@@ -20,6 +20,7 @@ use crate::{
     oracle_config::{
         OracleConfig
     },
+    fee_config::FeeConfig,
     helpers::{
         ns_to_ms,
     }
@@ -96,8 +97,7 @@ pub fn log_oracle_config(config: &OracleConfig, id: u64) {
                 "default_challenge_window_duration": config.default_challenge_window_duration,
                 "min_initial_challenge_window_duration": config.min_initial_challenge_window_duration,
                 "final_arbitrator_invoke_amount": config.final_arbitrator_invoke_amount,
-                "resolution_fee_percentage": config.resolution_fee_percentage,
-                
+
                 "date": U64(ns_to_ms(env::block_timestamp())),
                 "block_height": U64(env::block_index()),
             }
@@ -254,15 +254,17 @@ pub fn log_whitelist(requestor: &RegistryEntry, active: bool) {
     );
 }
 
-pub fn log_update_market_cap(market_cap: U128) {
+pub fn log_fee_config(fee_config: &FeeConfig) {
     env::log(
         json!({
-            "type": "market_cap",
+            "type": "fee_config",
             "action": "update",
-            "cap_id": format!("mc_{}", env::block_index()),
+            "cap_id": format!("fc_{}", env::block_index()),
             "params": {
-                "id": format!("mc_{}", env::block_index()),
-                "market_cap": market_cap,
+                "id": format!("fc_{}", env::block_index()),
+                "flux_market_cap": fee_config.flux_market_cap,
+                "total_value_staked": fee_config.total_value_staked,
+                "resolution_fee_percentage": fee_config.resolution_fee_percentage,
                 "date": U64(ns_to_ms(env::block_timestamp())),
                 "block_height": U64(env::block_index()),
             }

--- a/oracle/src/oracle_config.rs
+++ b/oracle/src/oracle_config.rs
@@ -17,7 +17,7 @@ pub struct OracleConfig {
     pub default_challenge_window_duration: WrappedTimestamp,
     pub min_initial_challenge_window_duration: WrappedTimestamp,
     pub final_arbitrator_invoke_amount: U128, // Amount of tokens that when bonded in a single `ResolutionWindow` should trigger the final arbitrator
-    pub resolution_fee_percentage: u16, // Percentage of requesters `tvl` behind the request that's to be paid out to resolutors, denominated in 1e4 so 1 = 0.01% - 10000 = 100%
+    // pub resolution_fee_percentage: u16, // Percentage of requesters `tvl` behind the request that's to be paid out to resolutors, denominated in 1e4 so 1 = 0.01% - 10000 = 100%
 }
 
 #[near_bindgen]

--- a/oracle/src/storage_manager.rs
+++ b/oracle/src/storage_manager.rs
@@ -193,14 +193,11 @@ mod mock_token_basic_tests {
             default_challenge_window_duration: U64(1000),
             min_initial_challenge_window_duration: U64(1000),
             final_arbitrator_invoke_amount: U128(250),
-        }
-    }
-
-    fn fee_config() -> FeeConfig {
-        FeeConfig {
-            flux_market_cap: U128(50000),
-            total_value_staked: U128(10000),
-            resolution_fee_percentage: 5000, // 5%
+            fee: FeeConfig {
+                flux_market_cap: U128(50000),
+                total_value_staked: U128(10000),
+                resolution_fee_percentage: 5000, // 5%
+            }
         }
     }
 
@@ -229,7 +226,7 @@ mod mock_token_basic_tests {
     fn storage_manager_deposit() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
 
         let account = contract.get_storage_account(&alice());
         assert_eq!(account.available, 0);
@@ -259,7 +256,7 @@ mod mock_token_basic_tests {
     fn storage_manager_withdraw() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
 
         let account = contract.get_storage_account(&alice());
         assert_eq!(account.available, 0);
@@ -287,7 +284,7 @@ mod mock_token_basic_tests {
     fn storage_manager_withdraw_too_much() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
 
         let account = contract.get_storage_account(&alice());
         assert_eq!(account.available, 0);

--- a/oracle/src/storage_manager.rs
+++ b/oracle/src/storage_manager.rs
@@ -143,6 +143,7 @@ mod mock_token_basic_tests {
     use near_sdk::{ MockedBlockchain };
     use near_sdk::{ testing_env, VMContext };
     use crate::whitelist::CustomFeeStakeArgs;
+    use fee_config::FeeConfig;
 
     fn alice() -> AccountId {
         "alice.near".to_string()
@@ -192,7 +193,14 @@ mod mock_token_basic_tests {
             default_challenge_window_duration: U64(1000),
             min_initial_challenge_window_duration: U64(1000),
             final_arbitrator_invoke_amount: U128(250),
-            resolution_fee_percentage: 0,
+        }
+    }
+
+    fn fee_config() -> FeeConfig {
+        FeeConfig {
+            flux_market_cap: U128(50000),
+            total_value_staked: U128(10000),
+            resolution_fee_percentage: 5000, // 5%
         }
     }
 
@@ -221,7 +229,7 @@ mod mock_token_basic_tests {
     fn storage_manager_deposit() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config());
+        let mut contract = Contract::new(whitelist, config(), fee_config());
 
         let account = contract.get_storage_account(&alice());
         assert_eq!(account.available, 0);
@@ -251,7 +259,7 @@ mod mock_token_basic_tests {
     fn storage_manager_withdraw() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config());
+        let mut contract = Contract::new(whitelist, config(), fee_config());
 
         let account = contract.get_storage_account(&alice());
         assert_eq!(account.available, 0);
@@ -279,7 +287,7 @@ mod mock_token_basic_tests {
     fn storage_manager_withdraw_too_much() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config());
+        let mut contract = Contract::new(whitelist, config(), fee_config());
 
         let account = contract.get_storage_account(&alice());
         assert_eq!(account.available, 0);

--- a/oracle/src/whitelist.rs
+++ b/oracle/src/whitelist.rs
@@ -105,6 +105,7 @@ impl Contract {
 mod mock_token_basic_tests {
     use near_sdk::{ MockedBlockchain };
     use near_sdk::{ testing_env, VMContext };
+    use fee_config::FeeConfig;
     use super::*;
 
     fn alice() -> AccountId {
@@ -136,6 +137,14 @@ mod mock_token_basic_tests {
         }
     }
 
+    fn fee_config() -> FeeConfig {
+        FeeConfig {
+            flux_market_cap: U128(50000),
+            total_value_staked: U128(10000),
+            resolution_fee_percentage: 5000, // 5%
+        }
+    }
+
     fn config() -> oracle_config::OracleConfig {
         oracle_config::OracleConfig {
             gov: gov(),
@@ -147,7 +156,6 @@ mod mock_token_basic_tests {
             default_challenge_window_duration: U64(1000),
             min_initial_challenge_window_duration: U64(1000),
             final_arbitrator_invoke_amount: U128(25_000_000_000_000_000_000_000_000_000_000),
-            resolution_fee_percentage: 0,
         }
     }
 
@@ -176,7 +184,7 @@ mod mock_token_basic_tests {
     fn setting_initial_whitelist() {
         testing_env!(get_context(carol()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let contract = Contract::new(whitelist, config());
+        let contract = Contract::new(whitelist, config(), fee_config());
         let alice_is_whitelisted = contract.whitelist_contains(alice());
         let bob_is_whitelisted = contract.whitelist_contains(bob());
         let carol_is_whitelisted = contract.whitelist_contains(carol());
@@ -189,7 +197,7 @@ mod mock_token_basic_tests {
     fn whitelist_add_remove() {
         testing_env!(get_context(gov()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config());
+        let mut contract = Contract::new(whitelist, config(), fee_config());
 
         assert!(!contract.whitelist_contains(alice()));
         contract.add_to_whitelist(registry_entry(alice()));
@@ -203,7 +211,7 @@ mod mock_token_basic_tests {
     fn only_gov_can_add() {
         testing_env!(get_context(alice()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config());
+        let mut contract = Contract::new(whitelist, config(), fee_config());
         contract.add_to_whitelist(registry_entry(alice()));
     }
 
@@ -212,7 +220,7 @@ mod mock_token_basic_tests {
     fn only_gov_can_remove() {
         testing_env!(get_context(alice()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config());
+        let mut contract = Contract::new(whitelist, config(), fee_config());
         contract.remove_from_whitelist(registry_entry(alice()));
     }
 }

--- a/oracle/src/whitelist.rs
+++ b/oracle/src/whitelist.rs
@@ -137,14 +137,6 @@ mod mock_token_basic_tests {
         }
     }
 
-    fn fee_config() -> FeeConfig {
-        FeeConfig {
-            flux_market_cap: U128(50000),
-            total_value_staked: U128(10000),
-            resolution_fee_percentage: 5000, // 5%
-        }
-    }
-
     fn config() -> oracle_config::OracleConfig {
         oracle_config::OracleConfig {
             gov: gov(),
@@ -156,6 +148,11 @@ mod mock_token_basic_tests {
             default_challenge_window_duration: U64(1000),
             min_initial_challenge_window_duration: U64(1000),
             final_arbitrator_invoke_amount: U128(25_000_000_000_000_000_000_000_000_000_000),
+            fee: FeeConfig {
+                flux_market_cap: U128(50000),
+                total_value_staked: U128(10000),
+                resolution_fee_percentage: 5000, // 5%
+            }
         }
     }
 
@@ -184,7 +181,7 @@ mod mock_token_basic_tests {
     fn setting_initial_whitelist() {
         testing_env!(get_context(carol()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let contract = Contract::new(whitelist, config(), fee_config());
+        let contract = Contract::new(whitelist, config());
         let alice_is_whitelisted = contract.whitelist_contains(alice());
         let bob_is_whitelisted = contract.whitelist_contains(bob());
         let carol_is_whitelisted = contract.whitelist_contains(carol());
@@ -197,7 +194,7 @@ mod mock_token_basic_tests {
     fn whitelist_add_remove() {
         testing_env!(get_context(gov()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
 
         assert!(!contract.whitelist_contains(alice()));
         contract.add_to_whitelist(registry_entry(alice()));
@@ -211,7 +208,7 @@ mod mock_token_basic_tests {
     fn only_gov_can_add() {
         testing_env!(get_context(alice()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         contract.add_to_whitelist(registry_entry(alice()));
     }
 
@@ -220,7 +217,7 @@ mod mock_token_basic_tests {
     fn only_gov_can_remove() {
         testing_env!(get_context(alice()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
-        let mut contract = Contract::new(whitelist, config(), fee_config());
+        let mut contract = Contract::new(whitelist, config());
         contract.remove_from_whitelist(registry_entry(alice()));
     }
 }

--- a/oracle/tests/it/utils/oracle_utils.rs
+++ b/oracle/tests/it/utils/oracle_utils.rs
@@ -33,13 +33,11 @@ impl OracleUtils {
             default_challenge_window_duration: U64(1000),
             min_initial_challenge_window_duration: U64(1000),
             final_arbitrator_invoke_amount: U128(final_arbitrator_invoke_amount),
-            // resolution_fee_percentage: 10_000,
-        };
-
-        let fee_config = FeeConfig {
-            flux_market_cap: U128(50000),
-            total_value_staked: U128(10000),
-            resolution_fee_percentage: 5000, // 5%
+            fee: FeeConfig {
+                flux_market_cap: U128(50000),
+                total_value_staked: U128(10000),
+                resolution_fee_percentage: 5000, // 5%
+            }
         };
         
         // deploy token
@@ -60,8 +58,7 @@ impl OracleUtils {
                         new_registry_entry(TARGET_CONTRACT_ID.to_string(), CustomFeeStakeArgs::None)
                     ]
                 ), 
-                config,
-                fee_config
+                config
             )
         );
 

--- a/oracle/tests/it/utils/oracle_utils.rs
+++ b/oracle/tests/it/utils/oracle_utils.rs
@@ -1,6 +1,7 @@
 use crate::utils::*;
 use oracle::oracle_config::OracleConfig;
 use oracle::whitelist::{RegistryEntry, CustomFeeStakeArgs};
+use oracle::fee_config::FeeConfig;
 
 pub struct OracleUtils {
     pub contract: ContractAccount<OracleContract>
@@ -32,7 +33,13 @@ impl OracleUtils {
             default_challenge_window_duration: U64(1000),
             min_initial_challenge_window_duration: U64(1000),
             final_arbitrator_invoke_amount: U128(final_arbitrator_invoke_amount),
-            resolution_fee_percentage: 10_000,
+            // resolution_fee_percentage: 10_000,
+        };
+
+        let fee_config = FeeConfig {
+            flux_market_cap: U128(50000),
+            total_value_staked: U128(10000),
+            resolution_fee_percentage: 5000, // 5%
         };
         
         // deploy token
@@ -53,7 +60,8 @@ impl OracleUtils {
                         new_registry_entry(TARGET_CONTRACT_ID.to_string(), CustomFeeStakeArgs::None)
                     ]
                 ), 
-                config
+                config,
+                fee_config
             )
         );
 


### PR DESCRIPTION
Closes #17 

- added `flux_market_cap` as a contract attribute (more efficient than putting in config to avoid unnecessary deserializations), initialized to a huge number just to be safe
- created `log_update_market_cap()` for logger
- assumes only council (through DAO) can call `set_market_cap()`