### PR TITLE
Feat/set_outcome() refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,3 @@ lto = true
 debug = false
 panic = "abort"
 overflow-checks = true
-

--- a/oracle/src/callback_args.rs
+++ b/oracle/src/callback_args.rs
@@ -54,11 +54,6 @@ pub struct ChallengeDataRequestArgs {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct FinalizeDataRequestArgs {
-    pub request_id: U64,
-}
-
-#[derive(Serialize, Deserialize)]
 pub struct SetPaidFeeArgs {
     pub request_id: U64,
 }

--- a/oracle/src/callback_args.rs
+++ b/oracle/src/callback_args.rs
@@ -57,3 +57,8 @@ pub struct ChallengeDataRequestArgs {
 pub struct FinalizeDataRequestArgs {
     pub request_id: U64,
 }
+
+#[derive(Serialize, Deserialize)]
+pub struct SetPaidFeeArgs {
+    pub request_id: U64,
+}

--- a/oracle/src/data_request.rs
+++ b/oracle/src/data_request.rs
@@ -721,8 +721,8 @@ impl Contract {
         dr.paid_fee = paid_fee;
         dr.return_validity_bond(config.bond_token);
 
+        dr.target_contract.set_outcome(U64(request_id), dr.requestor.clone(), dr.finalized_outcome.as_ref().unwrap().clone(), dr.tags.clone());
         self.data_requests.replace(request_id, &dr);
-        // dr.target_contract.set_outcome(U64(request_id), dr.requestor.clone(), dr.finalized_outcome.as_ref().unwrap().clone(), dr.tags.clone());
 
         logger::log_update_data_request(&dr);
 

--- a/oracle/src/data_request.rs
+++ b/oracle/src/data_request.rs
@@ -722,6 +722,7 @@ impl Contract {
         dr.return_validity_bond(config.bond_token);
 
         self.data_requests.replace(request_id, &dr);
+        // dr.target_contract.set_outcome(U64(request_id), dr.requestor.clone(), dr.finalized_outcome.as_ref().unwrap().clone(), dr.tags.clone());
 
         logger::log_update_data_request(&dr);
 

--- a/oracle/src/fungible_token_receiver.rs
+++ b/oracle/src/fungible_token_receiver.rs
@@ -8,7 +8,8 @@ use near_sdk::PromiseOrValue;
 pub enum Payload {
     NewDataRequest(NewDataRequestArgs),
     StakeDataRequest(StakeDataRequestArgs),
-    FinalizeDataRequest(FinalizeDataRequestArgs)
+    FinalizeDataRequest(FinalizeDataRequestArgs),
+    SetPaidFee(SetPaidFeeArgs)
 }
 
 pub trait FungibleTokenReceiver {
@@ -33,6 +34,7 @@ impl FungibleTokenReceiver for Contract {
             Payload::NewDataRequest(payload) => self.ft_dr_new_callback(sender_id.clone(), amount.into(), payload).into(),
             Payload::StakeDataRequest(payload) => self.dr_stake(sender_id.clone(), amount.into(), payload),
             Payload::FinalizeDataRequest(payload) => self.dr_proceed_finalization(amount.into(), sender_id.clone(), payload.request_id.into()),
+            Payload::SetPaidFee(payload) => self.set_claimed_fee(amount.into(), sender_id.clone(), payload.request_id.into()),
         };
 
         self.use_storage(&sender_id, initial_storage_usage, account.available);

--- a/oracle/src/fungible_token_receiver.rs
+++ b/oracle/src/fungible_token_receiver.rs
@@ -8,7 +8,6 @@ use near_sdk::PromiseOrValue;
 pub enum Payload {
     NewDataRequest(NewDataRequestArgs),
     StakeDataRequest(StakeDataRequestArgs),
-    FinalizeDataRequest(FinalizeDataRequestArgs),
     SetPaidFee(SetPaidFeeArgs)
 }
 
@@ -33,7 +32,6 @@ impl FungibleTokenReceiver for Contract {
         let unspent = match payload {
             Payload::NewDataRequest(payload) => self.ft_dr_new_callback(sender_id.clone(), amount.into(), payload).into(),
             Payload::StakeDataRequest(payload) => self.dr_stake(sender_id.clone(), amount.into(), payload),
-            Payload::FinalizeDataRequest(payload) => self.dr_proceed_finalization(amount.into(), sender_id.clone(), payload.request_id.into()),
             Payload::SetPaidFee(payload) => self.set_claimed_fee(amount.into(), sender_id.clone(), payload.request_id.into()),
         };
 

--- a/oracle/src/helpers.rs
+++ b/oracle/src/helpers.rs
@@ -5,6 +5,7 @@ use near_sdk::{
     AccountId, 
     Balance,
     Promise,
+    PromiseResult
 };
 use crate::whitelist::CustomFeeStakeArgs;
 use crate::data_request::CustomFeeStake;
@@ -14,6 +15,19 @@ const STORAGE_PRICE_PER_BYTE: Balance = 100_000_000_000_000_000_000;
 construct_uint! {
     /// 256-bit unsigned integer.
     pub struct u256(4);
+}
+
+pub fn assert_one_yocto() {
+    assert_eq!(env::attached_deposit(), 1, "This function requires 1 yocto");
+}
+
+pub fn previous_promise_successful() -> bool {
+    // return wether the finalization call was successful
+    match env::promise_result(0) {
+        PromiseResult::NotReady => unreachable!(),
+        PromiseResult::Failed => false,
+        PromiseResult::Successful(_) => true
+    }
 }
 
 /*** operators that does not take decimals into account ***/

--- a/oracle/src/target_contract_handler.rs
+++ b/oracle/src/target_contract_handler.rs
@@ -2,7 +2,7 @@ use crate::*;
 use near_sdk::json_types::{ U64 };
 use near_sdk::borsh::{ self, BorshDeserialize, BorshSerialize };
 use near_sdk::serde::{ Deserialize, Serialize };
-use near_sdk::{ AccountId, Gas, ext_contract, PromiseOrValue, Promise };
+use near_sdk::{ AccountId, Gas, ext_contract, Promise };
 use data_request::Outcome;
 
 #[ext_contract]
@@ -40,7 +40,7 @@ impl TargetContract {
         outcome: data_request::Outcome,
         tags: Option<Vec<String>>,
         final_arbitrator_triggered: bool
-    ) -> PromiseOrValue<U128> {
+    ) -> Promise {
         target_contract_extern::set_outcome(
             request_id,
             requestor,
@@ -51,7 +51,7 @@ impl TargetContract {
             // NEAR params
             &self.0,
             1, 
-            GAS_BASE_SET_OUTCOME,
-        ).into()
+            GAS_BASE_SET_OUTCOME / 10,
+        )
     }
 }

--- a/oracle/src/target_contract_handler.rs
+++ b/oracle/src/target_contract_handler.rs
@@ -2,13 +2,12 @@ use crate::*;
 use near_sdk::json_types::{ U64 };
 use near_sdk::borsh::{ self, BorshDeserialize, BorshSerialize };
 use near_sdk::serde::{ Deserialize, Serialize };
-use near_sdk::{ AccountId, Gas, ext_contract, Promise, PromiseOrValue };
+use near_sdk::{ AccountId, Gas, ext_contract, PromiseOrValue };
 use data_request::Outcome;
 
 #[ext_contract]
 pub trait TargetContractExtern {
-    fn init_finalization(request_id: U64);
-    fn set_outcome(request_id: U64, requestor: AccountId, outcome: Outcome, tags: Option<Vec<String>>);
+    fn set_outcome(request_id: U64, requestor: AccountId, outcome: Outcome, tags: Option<Vec<String>>, final_arbitrator_triggered: bool);
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Deserialize, Serialize)]
@@ -17,26 +16,25 @@ pub struct TargetContract(pub AccountId);
 const GAS_BASE_SET_OUTCOME: Gas = 250_000_000_000_000;
 
 impl TargetContract {
-    pub fn init_finalization(&self, request_id: U64) -> PromiseOrValue<U128> {
-        target_contract_extern::init_finalization(
-            request_id,
-            &self.0,
-            1,
-            GAS_BASE_SET_OUTCOME
-        ).into()
-    }
-    
-    pub fn set_outcome(&self, request_id: U64, requestor: AccountId, outcome: data_request::Outcome, tags: Option<Vec<String>>) -> Promise {
+    pub fn set_outcome(
+        &self,
+        request_id: U64,
+        requestor: AccountId,
+        outcome: data_request::Outcome,
+        tags: Option<Vec<String>>,
+        final_arbitrator_triggered: bool
+    ) -> PromiseOrValue<U128> {
         target_contract_extern::set_outcome(
             request_id,
             requestor,
             outcome,
             tags,
+            final_arbitrator_triggered,
 
             // NEAR params
             &self.0,
-            0, 
+            1, 
             GAS_BASE_SET_OUTCOME,
-        )
+        ).into()
     }
 }

--- a/oracle/src/target_contract_handler.rs
+++ b/oracle/src/target_contract_handler.rs
@@ -2,12 +2,13 @@ use crate::*;
 use near_sdk::json_types::{ U64 };
 use near_sdk::borsh::{ self, BorshDeserialize, BorshSerialize };
 use near_sdk::serde::{ Deserialize, Serialize };
-use near_sdk::{ AccountId, Gas, ext_contract, PromiseOrValue };
+use near_sdk::{ AccountId, Gas, ext_contract, PromiseOrValue, Promise };
 use data_request::Outcome;
 
 #[ext_contract]
 pub trait TargetContractExtern {
     fn set_outcome(request_id: U64, requestor: AccountId, outcome: Outcome, tags: Option<Vec<String>>, final_arbitrator_triggered: bool);
+    fn claim_fee(request_id: U64, fee_percentage: u16);
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Deserialize, Serialize)]
@@ -16,6 +17,22 @@ pub struct TargetContract(pub AccountId);
 const GAS_BASE_SET_OUTCOME: Gas = 250_000_000_000_000;
 
 impl TargetContract {
+    pub fn claim_fee(
+        &self,
+        request_id: U64,
+        fee_percentage: u16
+    ) -> Promise {
+        target_contract_extern::claim_fee(
+            request_id, 
+            fee_percentage,
+
+            // NEAR params
+            &self.0,
+            1,
+            GAS_BASE_SET_OUTCOME,
+        )
+    }
+
     pub fn set_outcome(
         &self,
         request_id: U64,

--- a/oracle/src/whitelist.rs
+++ b/oracle/src/whitelist.rs
@@ -22,6 +22,7 @@ pub struct RegistryEntry {
     pub custom_fee: CustomFeeStakeArgs,
     pub code_base_url: Option<String>
 }
+// 
 
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct Whitelist(LookupMap<AccountId, RegistryEntry>);

--- a/oracle/tests/it/dr_basic_tests.rs
+++ b/oracle/tests/it/dr_basic_tests.rs
@@ -9,38 +9,38 @@ fn dr_new_test() {
     assert!(dr_exist, "something went wrong during dr creation");
 }
 
-#[test]
-fn dr_resolution_flow_test() {
-    let stake_amount = to_yocto("250"); 
-    let stake_cost = 200;
-    let validity_bond = 100;
-    let init_res = TestUtils::init(None);
-    let init_balance_alice = init_res.alice.get_token_balance(None);
+// #[test]
+// fn dr_resolution_flow_test() {
+//     let stake_amount = to_yocto("250"); 
+//     let stake_cost = 200;
+//     let validity_bond = 100;
+//     let init_res = TestUtils::init(None);
+//     let init_balance_alice = init_res.alice.get_token_balance(None);
 
-    let _res = init_res.alice.dr_new();
-    let _post_new_balance_oracle = init_res.alice.get_token_balance(Some(ORACLE_CONTRACT_ID.to_string()));
+//     let _res = init_res.alice.dr_new();
+//     let _post_new_balance_oracle = init_res.alice.get_token_balance(Some(ORACLE_CONTRACT_ID.to_string()));
     
-    let dr_exist = init_res.alice.dr_exists(0);
-    assert!(dr_exist, "something went wrong during dr creation");
-    let outcome = data_request::Outcome::Answer(
-        data_request::AnswerType::String("test".to_string())
-    );
-    let _res = init_res.alice.stake(0, outcome, stake_amount);
+//     let dr_exist = init_res.alice.dr_exists(0);
+//     assert!(dr_exist, "something went wrong during dr creation");
+//     let outcome = data_request::Outcome::Answer(
+//         data_request::AnswerType::String("test".to_string())
+//     );
+//     let _res = init_res.alice.stake(0, outcome, stake_amount);
 
-    let _post_stake_balance_oracle = init_res.alice.get_token_balance(Some(ORACLE_CONTRACT_ID.to_string()));
-    let post_stake_balance_alice = init_res.alice.get_token_balance(None);
-    assert_eq!(post_stake_balance_alice, init_balance_alice - stake_cost - validity_bond);
+//     let _post_stake_balance_oracle = init_res.alice.get_token_balance(Some(ORACLE_CONTRACT_ID.to_string()));
+//     let post_stake_balance_alice = init_res.alice.get_token_balance(None);
+//     assert_eq!(post_stake_balance_alice, init_balance_alice - stake_cost - validity_bond);
 
-    init_res.treasurer.ft_transfer(&TARGET_CONTRACT_ID, 100_000);
+//     init_res.treasurer.ft_transfer(&TARGET_CONTRACT_ID, 100_000);
 
-    let pre_outcome = init_res.alice.get_outcome(0);
-    println!("Outcome on target before finalize: {:?}", pre_outcome);
-    init_res.alice.finalize(0);
-    let post_outcome = init_res.alice.get_outcome(0);
-    println!("Outcome on target after finalize: {:?}", post_outcome);
-    init_res.alice.claim(0);
+//     let pre_outcome = init_res.alice.get_outcome(0);
+//     println!("Outcome on target before finalize: {:?}", pre_outcome);
+//     init_res.alice.finalize(0);
+//     let post_outcome = init_res.alice.get_outcome(0);
+//     println!("Outcome on target after finalize: {:?}", post_outcome);
+//     init_res.alice.claim(0);
     
-    let post_claim_balance_alice = init_res.alice.get_token_balance(None);
-    assert_eq!(post_claim_balance_alice, init_balance_alice);
-}
+//     let post_claim_balance_alice = init_res.alice.get_token_balance(None);
+//     assert_eq!(post_claim_balance_alice, init_balance_alice);
+// }
 

--- a/oracle/tests/it/dr_basic_tests.rs
+++ b/oracle/tests/it/dr_basic_tests.rs
@@ -32,7 +32,12 @@ fn dr_resolution_flow_test() {
     assert_eq!(post_stake_balance_alice, init_balance_alice - stake_cost - validity_bond);
 
     init_res.treasurer.ft_transfer(&TARGET_CONTRACT_ID, 100_000);
+
+    let pre_outcome = init_res.alice.get_outcome(0);
+    println!("Outcome on target before finalize: {:?}", pre_outcome);
     init_res.alice.finalize(0);
+    let post_outcome = init_res.alice.get_outcome(0);
+    println!("Outcome on target after finalize: {:?}", post_outcome);
     init_res.alice.claim(0);
     
     let post_claim_balance_alice = init_res.alice.get_token_balance(None);

--- a/oracle/tests/it/dr_scenario_tests.rs
+++ b/oracle/tests/it/dr_scenario_tests.rs
@@ -168,11 +168,11 @@ fn dr_scenario_2() {
     
     // finalize
     let pre_outcome = init_res.alice.get_outcome(0);
-    println!("Outcome before finalize: {:?}", pre_outcome);
+    println!("Outcome on target before finalize: {:?}", pre_outcome);
     init_res.treasurer.ft_transfer(&TARGET_CONTRACT_ID, 100_000);
     init_res.alice.finalize(0);
     let post_outcome = init_res.alice.get_outcome(0);
-    println!("Outcome after finalize: {:?}", post_outcome);
+    println!("Outcome on target after finalize: {:?}", post_outcome);
 
     // claim
     init_res.bob.claim(0);

--- a/oracle/tests/it/dr_scenario_tests.rs
+++ b/oracle/tests/it/dr_scenario_tests.rs
@@ -63,9 +63,16 @@ fn dr_scenario_1() {
     println!("Bob has spent {} altogether on staking", pre_claim_difference_bob);
     println!("Carol has spent {} altogether on staking", pre_claim_difference_carol);
     
+    // finalize
     println!("Request interface balance before claim: {}", init_res.alice.get_token_balance(Some(REQUEST_INTERFACE_CONTRACT_ID.to_string())));
+    let pre_outcome = init_res.alice.get_outcome(0);
+    println!("Outcome before finalize: {:?}", pre_outcome);
     let correct_outcome = data_request::Outcome::Answer(data_request::AnswerType::String("test".to_string()));
     init_res.alice.dr_final_arbitrator_finalize(0, correct_outcome);
+    let post_outcome = init_res.alice.get_outcome(0);
+    println!("Outcome after finalize: {:?}", post_outcome);
+
+    // claim
     init_res.bob.claim(0);
     // init_res.carol.claim(0);
     
@@ -159,8 +166,15 @@ fn dr_scenario_2() {
     println!("Jasper has spent {} altogether on staking", pre_claim_difference_jasper);
     println!("Peter has spent {} altogether on staking", pre_claim_difference_peter);
     
+    // finalize
+    let pre_outcome = init_res.alice.get_outcome(0);
+    println!("Outcome before finalize: {:?}", pre_outcome);
     init_res.treasurer.ft_transfer(&TARGET_CONTRACT_ID, 100_000);
     init_res.alice.finalize(0);
+    let post_outcome = init_res.alice.get_outcome(0);
+    println!("Outcome after finalize: {:?}", post_outcome);
+
+    // claim
     init_res.bob.claim(0);
     init_res.carol.claim(0);
     init_res.jasper.claim(0);
@@ -193,6 +207,7 @@ fn dr_scenario_2() {
     println!("Jasper gained {} from claim for a total profit of {}", post_stake_difference_jasper, post_total_difference_jasper);
     println!("Peter gained {} from claim for a total profit of {}", post_stake_difference_peter, post_total_difference_peter);
     println!("Alice lost {} altogether", post_total_difference_alice);
+
     
 }
 

--- a/oracle/tests/it/main.rs
+++ b/oracle/tests/it/main.rs
@@ -2,5 +2,6 @@
 mod utils;
 
 mod init;
+mod dr_resolution_tests;
 mod dr_basic_tests;
 mod dr_scenario_tests;

--- a/oracle/tests/it/utils/account_utils.rs
+++ b/oracle/tests/it/utils/account_utils.rs
@@ -128,10 +128,29 @@ impl TestAccount {
         res
     }
 
+    fn claim_fee(
+        &self,
+        dr_id: u64
+    ) -> ExecutionResult {
+        let res = self.account.call(
+            ORACLE_CONTRACT_ID.to_string(), 
+            "dr_claim_fee", 
+            json!({
+                "request_id": U64(dr_id)
+            }).to_string().as_bytes(),
+            DEFAULT_GAS,
+            1
+        );
+
+        res.assert_success();
+        res
+    }
+
     pub fn finalize(
         &self,
         dr_id: u64
     ) -> ExecutionResult {
+        self.claim_fee(dr_id);
         let res = self.account.call(
             ORACLE_CONTRACT_ID.to_string(), 
             "dr_finalize", 
@@ -139,7 +158,7 @@ impl TestAccount {
                 "request_id": U64(dr_id)
             }).to_string().as_bytes(),
             DEFAULT_GAS,
-            1600000000000000000000
+            0
         );
 
         res.assert_success();

--- a/oracle/tests/it/utils/account_utils.rs
+++ b/oracle/tests/it/utils/account_utils.rs
@@ -1,5 +1,6 @@
 use crate::utils::*;
 use oracle::data_request::DataRequestDataType;
+use target_contract::Outcome;
 
 pub fn init_balance() -> u128 {
     to_yocto("100000")
@@ -57,6 +58,16 @@ impl TestAccount {
         ).unwrap_json()
     }
 
+    pub fn get_outcome(&self, id: u64) -> Option<Outcome> {
+        self.account.view(
+            TARGET_CONTRACT_ID.to_string(),
+            "get_outcome",
+            json!({
+                "request_id": U64(id)
+            }).to_string().as_bytes()
+        ).unwrap_json()
+    }
+    
     /*** Setters ***/
     pub fn dr_new(
         &self,

--- a/oracle/tests/it/utils/target_contract_utils.rs
+++ b/oracle/tests/it/utils/target_contract_utils.rs
@@ -19,7 +19,8 @@ impl TargetContractUtils {
             // init method
             init_method: new(
                 ORACLE_CONTRACT_ID.to_string(),
-                TOKEN_CONTRACT_ID.to_string()
+                TOKEN_CONTRACT_ID.to_string(),
+                REQUEST_INTERFACE_CONTRACT_ID.to_string()
             )
         );
 

--- a/target-contract/src/lib.rs
+++ b/target-contract/src/lib.rs
@@ -85,6 +85,13 @@ impl TargetContract {
         let fee = 100; // TODO: calc fee
         ext_token_contract::ft_transfer_call(self.oracle.to_string(), fee.into(), None, payload, &self.fee_token, 1, GAS_BASE_SET_OUTCOME)
     }
+
+    pub fn get_outcome(
+        self,
+        request_id: U64
+    ) -> Option<Outcome> {
+        self.data_requests.get(&request_id)
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/target-contract/src/lib.rs
+++ b/target-contract/src/lib.rs
@@ -9,8 +9,21 @@ near_sdk::setup_alloc!();
 const GAS_BASE_SET_OUTCOME: Gas = 200_000_000_000_000;
 
 #[derive(BorshSerialize, BorshDeserialize, Deserialize, Serialize, Debug, PartialEq, Clone)]
+pub struct AnswerNumberType {
+    pub value: U128,
+    pub multiplier: U128,
+    pub negative: bool,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Deserialize, Serialize, Debug, PartialEq, Clone)]
+pub enum AnswerType {
+    Number(AnswerNumberType),
+    String(String)
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Deserialize, Serialize, Debug, PartialEq, Clone)]
 pub enum Outcome {
-    Answer(String),
+    Answer(AnswerType),
     Invalid
 }
 


### PR DESCRIPTION
- use updated `AnswerType` struct on target contract to match shape from oracle
- `set_outcome()` sets outcome on target contract by combining `init_finalization()` and `set_outcome()`
- target contract now has `DataRequestStatus` enum
- created `get_outcome()` on target contract for testing, see `dr_scenario_1` for final arb finalize and `dr_scenario_2` finalize