### PR TITLE
Fix/data request summary types

### DIFF
--- a/oracle/src/data_request.rs
+++ b/oracle/src/data_request.rs
@@ -418,11 +418,11 @@ pub struct DataRequestSummary {
     pub requestor: AccountId,
     pub creator: AccountId,
     pub finalized_outcome: Option<Outcome>,
-    pub resolution_windows: Vector<ResolutionWindowSummary>,
+    pub resolution_windows: Vec<ResolutionWindowSummary>,
     pub settlement_time: u64,
     pub initial_challenge_period: Duration,
     pub final_arbitrator_triggered: bool,
-    pub target_contract: target_contract_handler::TargetContract,
+    pub target_contract: AccountId,
     pub tags: Option<Vec<String>>,
     pub paid_fee: WrappedBalance
 }
@@ -614,7 +614,8 @@ impl DataRequestView for DataRequest {
      */
     fn summarize_dr(&self) -> DataRequestSummary {
         // format resolution windows inside this data request
-        let resolution_windows = Vector::new(format!("frw{}", self.id).as_bytes().to_vec());
+        // let resolution_windows = Vector::new(format!("frw{}", self.id).as_bytes().to_vec());
+        let mut resolution_windows = Vec::new();
         for i in self.resolution_windows.iter() {
             let rw = ResolutionWindowSummary {
                 round: i.round,
@@ -623,23 +624,23 @@ impl DataRequestView for DataRequest {
                 bond_size: i.bond_size,
                 bonded_outcome: i.bonded_outcome,
             };
-            resolution_windows.push(&rw);
+            resolution_windows.push(rw);
         }
 
         // format data request
         DataRequestSummary {
             id: self.id,
-            description: self.description,
-            outcomes: self.outcomes,
-            requestor: self.requestor,
-            creator: self.creator,
-            finalized_outcome: self.finalized_outcome,
+            description: self.description.clone(),
+            outcomes: self.outcomes.clone(),
+            requestor: self.requestor.clone(),
+            creator: self.creator.clone(),
+            finalized_outcome: self.finalized_outcome.clone(),
             resolution_windows: resolution_windows,
             settlement_time: self.settlement_time,
             initial_challenge_period: self.initial_challenge_period,
             final_arbitrator_triggered: self.final_arbitrator_triggered,
-            target_contract: self.target_contract,
-            tags: self.tags,
+            target_contract: self.target_contract.0.clone(),
+            tags: self.tags.clone(),
             paid_fee: U128(self.paid_fee)
         }
     }

--- a/oracle/src/data_request.rs
+++ b/oracle/src/data_request.rs
@@ -819,7 +819,7 @@ impl Contract {
     }
 
     fn dr_get_expect(&self, id: U64) -> DataRequest {
-        self.data_requests.get(id.into()).expect("DataRequest with this id does not exist")
+        self.data_requests.get(id.into()).expect("ERR_DATA_REQUEST_NOT_FOUND")
     }
 
     pub fn get_request_by_id(&self, id: U64) -> Option<DataRequestSummary> {
@@ -1208,7 +1208,7 @@ mod mock_token_basic_tests {
     }
 
     #[test]
-    #[should_panic(expected = "DataRequest with this id does not exist")]
+    #[should_panic(expected = "ERR_DATA_REQUEST_NOT_FOUND")]
     fn dr_stake_not_existing() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
@@ -1466,7 +1466,7 @@ mod mock_token_basic_tests {
     }
 
     #[test]
-    #[should_panic(expected = "DataRequest with this id does not exist")]
+    #[should_panic(expected = "ERR_DATA_REQUEST_NOT_FOUND")]
     fn dr_unstake_invalid_id() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);
@@ -1555,7 +1555,7 @@ mod mock_token_basic_tests {
     }
 
     #[test]
-    #[should_panic(expected = "DataRequest with this id does not exist")]
+    #[should_panic(expected = "ERR_DATA_REQUEST_NOT_FOUND")]
     fn dr_claim_invalid_id() {
         testing_env!(get_context(token()));
         let whitelist = Some(vec![registry_entry(bob()), registry_entry(carol())]);

--- a/oracle/src/data_request.rs
+++ b/oracle/src/data_request.rs
@@ -47,7 +47,7 @@ pub struct CorrectStake {
     pub user_stake: Balance,
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Deserialize, Serialize)]
+#[derive(BorshSerialize, BorshDeserialize, Deserialize, Serialize, Clone)]
 pub struct Source {
     pub end_point: String,
     pub source_path: String
@@ -414,13 +414,15 @@ pub struct ResolutionWindowSummary {
 pub struct DataRequestSummary {
     pub id: u64,
     pub description: Option<String>,
+    pub sources: Vec<Source>,
     pub outcomes: Option<Vec<String>>,
     pub requestor: AccountId,
     pub creator: AccountId,
     pub finalized_outcome: Option<Outcome>,
     pub resolution_windows: Vec<ResolutionWindowSummary>,
-    pub settlement_time: u64,
-    pub initial_challenge_period: Duration,
+    pub global_config_id: U64,
+    pub settlement_time: U64,
+    pub initial_challenge_period: U64,
     pub final_arbitrator_triggered: bool,
     pub target_contract: AccountId,
     pub tags: Option<Vec<String>>,
@@ -614,7 +616,6 @@ impl DataRequestView for DataRequest {
      */
     fn summarize_dr(&self) -> DataRequestSummary {
         // format resolution windows inside this data request
-        // let resolution_windows = Vector::new(format!("frw{}", self.id).as_bytes().to_vec());
         let mut resolution_windows = Vec::new();
         for i in self.resolution_windows.iter() {
             let rw = ResolutionWindowSummary {
@@ -631,13 +632,15 @@ impl DataRequestView for DataRequest {
         DataRequestSummary {
             id: self.id,
             description: self.description.clone(),
+            sources: self.sources.clone(),
             outcomes: self.outcomes.clone(),
             requestor: self.requestor.clone(),
             creator: self.creator.clone(),
             finalized_outcome: self.finalized_outcome.clone(),
             resolution_windows: resolution_windows,
-            settlement_time: self.settlement_time,
-            initial_challenge_period: self.initial_challenge_period,
+            global_config_id: U64(self.global_config_id),
+            settlement_time: U64(self.settlement_time),
+            initial_challenge_period: U64(self.initial_challenge_period),
             final_arbitrator_triggered: self.final_arbitrator_triggered,
             target_contract: self.target_contract.0.clone(),
             tags: self.tags.clone(),


### PR DESCRIPTION
- created ResolutionWindowSummary, DataRequestSummary structs for get methods (fixes build error)
- created `dr_summarize()` to transform a DataRequest into a DataRequestSummary, keeping most fields and using json types