### PR TITLE
Feat/optional whitelist on request interface

### DIFF
--- a/oracle/tests/it/utils/request_interface_utils.rs
+++ b/oracle/tests/it/utils/request_interface_utils.rs
@@ -19,7 +19,8 @@ impl RequestInterfaceUtils {
             // init method
             init_method: new(
                 ORACLE_CONTRACT_ID.to_string(),
-                TOKEN_CONTRACT_ID.to_string()
+                TOKEN_CONTRACT_ID.to_string(),
+                None
             )
         );
         


### PR DESCRIPTION
- if request interface is initialized with whitelist, `create_data_request()` checks to see if its caller is contained in the whitelist. Useful option to have on the request interface template as it will likely be a common pattern to have select addresses making data requests